### PR TITLE
fix: graph name changed (VE to FC)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -638,7 +638,7 @@ const genDocx = async (data, zonesTable, rec, name, age, poids, fc1, fc2, s1, s2
   };
 
   pushChart(vo2Cap, "Graphique VO₂");
-  pushChart(veCap, "Graphique VE");
+  pushChart(veCap, "Graphique FC");
 
   ch.push(new Paragraph({ children: [new PageBreak()] }));
   ch.push(new Paragraph({ spacing: { before: 50, after: 60 }, children: [new TextRun({ text: "Recommandations", bold: true, size: 26 })] }));


### PR DESCRIPTION
This pull request makes a small but important correction to the generated document in the `genDocx` function. The label for a chart was updated to accurately reflect its content.

- The label for the `veCap` chart was changed from "Graphique VE" to "Graphique FC" to ensure the chart title matches the displayed data.